### PR TITLE
Windows support

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -3,7 +3,6 @@ package git
 import (
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 )
@@ -25,7 +24,7 @@ func UnpackRefs(repoPath string) error {
 		infos := strings.Split(ref, " ")
 		refPath := filepath.Join(repoPath, infos[1])
 		os.RemoveAll(refPath)
-		os.MkdirAll(path.Dir(refPath), os.ModePerm)
+		os.MkdirAll(filepath.Dir(refPath), os.ModePerm)
 		if err = ioutil.WriteFile(refPath, []byte(infos[0]), os.ModePerm); err != nil {
 			return err
 		}

--- a/repo_branch.go
+++ b/repo_branch.go
@@ -13,17 +13,17 @@ var (
 )
 
 func IsBranchExist(repoPath, branchName string) bool {
-	branchPath := filepath.Join(repoPath, "refs/heads", branchName)
+	branchPath := filepath.Join(repoPath, "refs", "heads", branchName)
 	return isFile(branchPath)
 }
 
 func (repo *Repository) IsBranchExist(branchName string) bool {
-	branchPath := filepath.Join(repo.Path, "refs/heads", branchName)
+	branchPath := filepath.Join(repo.Path, "refs", "heads", branchName)
 	return isFile(branchPath)
 }
 
 func (repo *Repository) GetBranches() ([]string, error) {
-	return repo.readRefDir("refs/heads", "")
+	return repo.readRefDir(filepath.Join("refs", "heads"), "")
 }
 
 func (repo *Repository) CreateBranch(branchName, idStr string) error {
@@ -36,7 +36,7 @@ func (repo *Repository) createRef(head, branchName, idStr string) error {
 		return err
 	}
 
-	branchPath := filepath.Join(repo.Path, "refs/"+head, branchName)
+	branchPath := filepath.Join(repo.Path, "refs", head, branchName)
 	if isFile(branchPath) {
 		return ErrBranchExisted
 	}
@@ -92,7 +92,7 @@ func CreateBranch(repoPath, branchName, id string) error {
 }
 
 func CreateRef(head, repoPath, branchName, id string) error {
-	branchPath := filepath.Join(repoPath, "refs/"+head, branchName)
+	branchPath := filepath.Join(repoPath, "refs", head, branchName)
 	if isFile(branchPath) {
 		return ErrBranchExisted
 	}

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -7,17 +7,17 @@ import (
 )
 
 func (repo *Repository) IsTagExist(tagName string) bool {
-	tagPath := filepath.Join(repo.Path, "refs/tags", tagName)
+	tagPath := filepath.Join(repo.Path, "refs", "tags", tagName)
 	return isFile(tagPath)
 }
 
 func (repo *Repository) TagPath(tagName string) string {
-	return filepath.Join(repo.Path, "refs/tags", tagName)
+	return filepath.Join(repo.Path, "refs", "tags", tagName)
 }
 
 // GetTags returns all tags of given repository.
 func (repo *Repository) GetTags() ([]string, error) {
-	return repo.readRefDir("refs/tags", "")
+	return repo.readRefDir(filepath.Join("refs", "tags"), "")
 }
 
 func (repo *Repository) CreateTag(tagName, idStr string) error {

--- a/tree.go
+++ b/tree.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"errors"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -54,7 +54,7 @@ func (t *Tree) walk(dir string, walkFn TreeWalkFunc) error {
 		if te.Type == ObjectTree {
 			subTree, subErr = t.walkSubtree(te)
 		}
-		d := path.Join(dir, te.name)
+		d := filepath.Join(dir, te.name)
 		if err := walkFn(d, te, subErr); err != nil {
 			if err == SkipDir {
 				continue
@@ -77,7 +77,7 @@ func (t *Tree) SubTree(rpath string) (*Tree, error) {
 		return t, nil
 	}
 
-	paths := strings.Split(rpath, "/")
+	paths := strings.Split(filepath.ToSlash(rpath), "/")
 	var err error
 	var g = t
 	var p = t

--- a/tree_blob.go
+++ b/tree_blob.go
@@ -3,6 +3,7 @@ package git
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -13,7 +14,7 @@ func (t *Tree) GetTreeEntryByPath(rpath string) (*TreeEntry, error) {
 		return nil, ErrNotExist
 	}
 
-	parts := strings.Split(path.Clean(rpath), "/")
+	parts := strings.Split(path.Clean(filepath.ToSlash(rpath)), "/")
 	var err error
 	tree := t
 	for i, name := range parts {


### PR DESCRIPTION
- using `filepath.<func>` instead of `path.<func>` where needed
- when splitting filepath to components, converting it to path style first
