### PR TITLE
add mutex around commit and tag caches

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 // idx-file
@@ -47,8 +48,11 @@ type Repository struct {
 	Path       string
 	indexfiles map[string]*idxFile
 
-	commitCache map[sha1]*Commit
-	tagCache    map[sha1]*Tag
+	commitCacheMu sync.Mutex
+	commitCache   map[sha1]*Commit
+
+	tagCacheMu sync.Mutex
+	tagCache   map[sha1]*Tag
 }
 
 // Open the repository at the given path.

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -119,6 +119,9 @@ func (repo *Repository) GetCommit(commitId string) (*Commit, error) {
 }
 
 func (repo *Repository) getCommit(id sha1) (*Commit, error) {
+	repo.commitCacheMu.Lock()
+	defer repo.commitCacheMu.Unlock()
+
 	if repo.commitCache != nil {
 		if c, ok := repo.commitCache[id]; ok {
 			return c, nil

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -48,6 +48,9 @@ func (repo *Repository) GetTag(tagName string) (*Tag, error) {
 }
 
 func (repo *Repository) getTag(id sha1) (*Tag, error) {
+	repo.tagCacheMu.Lock()
+	defer repo.tagCacheMu.Unlock()
+
 	if repo.tagCache != nil {
 		if c, ok := repo.tagCache[id]; ok {
 			return c, nil


### PR DESCRIPTION
Allows multiple goroutines to use a single Repository.
